### PR TITLE
Replaced the Default Django IDs with UUID

### DIFF
--- a/src/applications/models.py
+++ b/src/applications/models.py
@@ -3,6 +3,7 @@ from users.models import CustomUser as User
 from courses.models import Course
 from enum import Enum
 from django.urls import reverse
+import uuid
 
 
 class ApplicationStatus(Enum):
@@ -19,6 +20,7 @@ class ApplicationStatus(Enum):
     CONFIRMED = 4
 
 class Application(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     student = models.ForeignKey(User, on_delete=models.CASCADE, default=None)
     course = models.ForeignKey(Course, on_delete=models.CASCADE, default=None)
 

--- a/src/applications/urls.py
+++ b/src/applications/urls.py
@@ -1,11 +1,16 @@
-from django.urls import path
+from django.urls import path, re_path
 from .views import ApplicationCreateView, ApplicationListView, ApplicationDeleteView, ApplicationDetailView, ApplicationRejectView
 app_name = 'applications'
 
 urlpatterns = [
-    path('create/<int:pk>/', ApplicationCreateView.as_view(), name='application-create'),
     path('', ApplicationListView.as_view(), name='application-list'),
-    path('delete/<int:pk>/', ApplicationDeleteView.as_view(), name='application-delete'),
-    path('detail/<int:pk>/', ApplicationDetailView.as_view(), name='application-detail'),
-    path('reject/<int:pk>/', ApplicationRejectView.as_view(), name='application-reject'),
+    # path('create/<int:pk>/', ApplicationCreateView.as_view(), name='application-create'),
+   
+    # path('delete/<int:pk>/', ApplicationDeleteView.as_view(), name='application-delete'),
+    # path('detail/<int:pk>/', ApplicationDetailView.as_view(), name='application-detail'),
+    # path('reject/<int:pk>/', ApplicationRejectView.as_view(), name='application-reject'),
+    re_path(r'^create/(?P<pk>[0-9a-f-]+)/$', ApplicationCreateView.as_view(), name='application-create'),
+    re_path(r'^delete/(?P<pk>[0-9a-f-]+)/$', ApplicationDeleteView.as_view(), name='application-delete'),
+    re_path(r'^detail/(?P<pk>[0-9a-f-]+)/$', ApplicationDetailView.as_view(), name='application-detail'),
+    re_path(r'^reject/(?P<pk>[0-9a-f-]+)/$', ApplicationRejectView.as_view(), name='application-reject'),
 ]

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -2,9 +2,10 @@ from django.db import models
 from users.models import CustomUser
 from django.urls import reverse
 from django.db.models import Q
+import uuid
 
 class Course(models.Model):
-
+	id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 	term = models.CharField(max_length=100)
 	class_type = models.CharField(max_length=100)
 	course = models.CharField(max_length=100)

--- a/src/courses/urls.py
+++ b/src/courses/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, re_path
 from .views import UploadView, ListView, CloseView, CourseDetailView
 
 app_name = 'courses'
@@ -7,5 +7,6 @@ urlpatterns = [
 	path('', ListView.as_view(), name='course-list'),
     path('manage/', UploadView.as_view(), name='manage-course'),
     path('manage/archive/', CloseView.as_view(), name='archive-course'),
-    path('<int:pk>/', CourseDetailView.as_view(), name='course-detail'),
+    # path('<int:pk>/', CourseDetailView.as_view(), name='course-detail'),
+    re_path(r'^(?P<pk>[0-9a-f-]+)/$', CourseDetailView.as_view(), name='course-detail'),
 ]

--- a/src/offers/models.py
+++ b/src/offers/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from enum import Enum
+import uuid
 
 class OfferStatus(Enum):
     PENDING = 1
@@ -7,6 +8,7 @@ class OfferStatus(Enum):
     REJECTED = 3
 
 class Offer(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     application = models.ForeignKey('applications.Application', on_delete=models.CASCADE, related_name='offer_application')
     course = models.ForeignKey('courses.Course', on_delete=models.CASCADE, related_name='offer_course')
     recipient = models.ForeignKey('users.CustomUser', on_delete=models.CASCADE, related_name='offer_recipient')

--- a/src/offers/urls.py
+++ b/src/offers/urls.py
@@ -1,13 +1,19 @@
-from django.urls import path
+from django.urls import path, re_path
 from .views import OfferCreateView, OfferListView, OfferDeleteView, OfferAcceptView, OfferDetailView, OfferRejectView
 
 app_name = 'offers'
 
 urlpatterns = [
-    path('create/<int:pk>/', OfferCreateView.as_view(), name='offer-create'),
     path('', OfferListView.as_view(), name='offer-list'),
-    path('delete/<int:pk>/', OfferDeleteView.as_view(), name='offer-delete'),
-    path('accept/<int:pk>/', OfferAcceptView.as_view(), name='offer-accept'),
-    path('detail/<int:pk>/', OfferDetailView.as_view(), name='offer-detail'),
-    path('reject/<int:pk>/', OfferRejectView.as_view(), name='offer-reject'),
+
+    # path('create/<int:pk>/', OfferCreateView.as_view(), name='offer-create'),
+    # path('delete/<int:pk>/', OfferDeleteView.as_view(), name='offer-delete'),
+    # path('accept/<int:pk>/', OfferAcceptView.as_view(), name='offer-accept'),
+    # path('detail/<int:pk>/', OfferDetailView.as_view(), name='offer-detail'),
+    # path('reject/<int:pk>/', OfferRejectView.as_view(), name='offer-reject'),
+    re_path(r'^create/(?P<pk>[0-9a-f-]+)/$', OfferCreateView.as_view(), name='offer-create'),
+    re_path(r'^delete/(?P<pk>[0-9a-f-]+)/$', OfferDeleteView.as_view(), name='offer-delete'),
+    re_path(r'^accept/(?P<pk>[0-9a-f-]+)/$', OfferAcceptView.as_view(), name='offer-accept'),
+    re_path(r'^detail/(?P<pk>[0-9a-f-]+)/$', OfferDetailView.as_view(), name='offer-detail'),
+    re_path(r'^reject/(?P<pk>[0-9a-f-]+)/$', OfferRejectView.as_view(), name='offer-reject'),
 ]  

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from django.db import models
+import uuid
 
 class CustomUserManager(BaseUserManager):
     def create_user(self, email, password=None, **extra_fields):
@@ -18,6 +19,7 @@ class CustomUserManager(BaseUserManager):
         return self.create_user(email, password, **extra_fields)
 
 class CustomUser(AbstractBaseUser, PermissionsMixin):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     first_name = models.CharField(max_length=30, blank=True)
     last_name = models.CharField(max_length=30, blank=True)
     email = models.EmailField(unique=True)

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -1,10 +1,11 @@
-from django.urls import path
+from django.urls import path, re_path
 from .views import RegisterView, ProfileView
 from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('signup/', RegisterView.as_view(), name='signup'),
-    path('update/<int:pk>', ProfileView.as_view(), name='profile'),
+    # path('update/<int:pk>', ProfileView.as_view(), name='profile'),
     path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    re_path(r'^update/(?P<pk>[0-9a-f-]+)/$', ProfileView.as_view(), name='profile'),
 ]


### PR DESCRIPTION
Switched primary keys from integer IDs to UUIDs across the models: (`Application`, `Course`, `Offer`, and `CustomUser`). Updated related URLs to use `re_path` for UUID-based routing in `applications`, `courses`, `offers`, and `users` apps.

I did this to make it seem more professional and the transition to UUIDs also enhances data security and makes it more scalable in the future.

LMK what you think not sure if this is completely necessary but it's definitely a good addition
